### PR TITLE
Enable concatenation of charts with tiles

### DIFF
--- a/altair_tiles/__init__.py
+++ b/altair_tiles/__init__.py
@@ -1,8 +1,8 @@
 __version__ = "0.4.0dev"
 __all__ = ["add_tiles", "add_attribution", "create_tiles_chart", "providers"]
 
-import os
 import math
+import os
 from dataclasses import dataclass
 from typing import Final, List, Optional, Union, cast
 
@@ -43,11 +43,13 @@ def add_tiles(
         to the chart. You can also provide a custom text as a string or disable
         the attribution text by setting this to False. By default True
     width : Optional[int], optional
-        Manually set the width of the tile chart. This allows for using the tile chart in
-        concatenation operations, where it may otherwise fail to detect the correct width.
+        Manually set the width of the tile chart. This allows for using the tile chart
+        in concatenation operations, where it may otherwise fail to detect the correct
+        width.
     height : Optional[int], optional
-        Manually set the height of the tile chart. This allows for using the tile chart in
-        concatenation operations, where it may otherwise fail to detect the correct height.
+        Manually set the height of the tile chart. This allows for using the tile chart
+        in concatenation operations, where it may otherwise fail to detect the correct
+        height.
 
     Returns
     -------
@@ -123,11 +125,13 @@ def create_tiles_chart(
         have a chart, you can pass the projection of the chart, e.g. `chart.projection`.
         Defaults to True.
     width : Optional[int], optional
-        Manually set the width of the tile chart. This allows for using the tile chart in
-        concatenation operations, where it may otherwise fail to detect the correct width.
+        Manually set the width of the tile chart. This allows for using the tile chart
+        in concatenation operations, where it may otherwise fail to detect the correct
+        width.
     height : Optional[int], optional
-        Manually set the height of the tile chart. This allows for using the tile chart in
-        concatenation operations, where it may otherwise fail to detect the correct height.
+        Manually set the height of the tile chart. This allows for using the tile chart
+        in concatenation operations, where it may otherwise fail to detect the correct
+        height.
 
     Returns
     -------
@@ -300,15 +304,16 @@ def _create_nonstandalone_tiles_chart(
     # x and y below refer to the x and y coordinates on the chart, not the x and y
     # in the tile urls.
 
-    # Note that height and width may be (incorrectly) set to zero when used in a concatenated
-    # chart. In those cases, the childHeight and childWidth signals are instead set, but we
-    # cannot use these because they don't always exists and referencing an undefined signal
-    # throws an error.
+    # Note that height and width may be (incorrectly) set to zero when used in a
+    # concatenated chart. In those cases, the childHeight and childWidth signals are
+    # instead set, but we cannot use these because they don't always exists and
+    # referencing an undefined signal throws an error.
     #
-    # Instead, just use the manually provided dimensions to allow the caller to override the
-    # erroneous height or width signals.
+    # Instead, just use the manually provided dimensions to allow the caller to override
+    # the erroneous height or width signals.
     tiles = tiles.transform_filter(
-        f"datum.x < ({width or 'width'} + tile_size / 2) && datum.y < ({height or 'height'} + tile_size / 2)"
+        f"datum.x < ({width or 'width'} + tile_size / 2) && "
+        + f"datum.y < ({height or 'height'} + tile_size / 2)"
     )
 
     # Remove tile urls which are not valid for the given provider. Else, they would

--- a/altair_tiles/__init__.py
+++ b/altair_tiles/__init__.py
@@ -17,7 +17,7 @@ def add_tiles(
     provider: Union[str, TileProvider] = "OpenStreetMap.Mapnik",
     zoom: Optional[int] = None,
     attribution: Union[str, bool] = True,
-    width: Optinonal[int] = None,
+    width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> alt.LayerChart:
     """Adds tiles to a chart. The chart must have a geoshape mark and a Mercator
@@ -85,7 +85,7 @@ def create_tiles_chart(
     zoom: Optional[int] = None,
     attribution: Union[str, bool] = True,
     standalone: Union[bool, alt.Projection] = True,
-    width: Optinonal[int] = None,
+    width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> Union[alt.LayerChart, alt.Chart]:
     """Creates an Altair chart with tiles.
@@ -173,7 +173,7 @@ def _create_nonstandalone_tiles_chart(
     provider: TileProvider,
     zoom: Optional[int],
     attribution: Union[str, bool],
-    width: Optinonal[int],
+    width: Optional[int],
     height: Optional[int],
 ) -> Union[alt.Chart, alt.LayerChart]:
     # The calculations below are based on initial implementations in Vega

--- a/altair_tiles/__init__.py
+++ b/altair_tiles/__init__.py
@@ -266,7 +266,10 @@ def _create_nonstandalone_tiles_chart(
 
     one_side_grid_size = _calculate_one_side_grid_size(evaluated_zoom_level_ceil)
 
-    tile_list = alt.sequence(0, one_side_grid_size, as_="a", name=f"tile_list_{os.urandom(6).hex()}")
+    tile_list = alt.sequence(
+        0, one_side_grid_size, as_="a", name=f"tile_list_{os.urandom(6).hex()}"
+    )
+
     # Can be a layerchart after adding attribution
     tiles = (
         alt.Chart(tile_list)

--- a/altair_tiles/__init__.py
+++ b/altair_tiles/__init__.py
@@ -1,6 +1,7 @@
 __version__ = "0.4.0dev"
 __all__ = ["add_tiles", "add_attribution", "create_tiles_chart", "providers"]
 
+import os
 import math
 from dataclasses import dataclass
 from typing import Final, List, Optional, Union, cast
@@ -244,7 +245,7 @@ def _create_nonstandalone_tiles_chart(
 
     one_side_grid_size = _calculate_one_side_grid_size(evaluated_zoom_level_ceil)
 
-    tile_list = alt.sequence(0, one_side_grid_size, as_="a", name="tile_list")
+    tile_list = alt.sequence(0, one_side_grid_size, as_="a", name=f"tile_list_{os.urandom(6).hex()}")
     # Can be a layerchart after adding attribution
     tiles = (
         alt.Chart(tile_list)


### PR DESCRIPTION
I've applied two small fixes to enable concatenation of charts that include altair_tiles.

1. 4123a98f211c2d24971e56fc1acee0aaf1174756 The dataset name is now unique, fixing `Javascript Error: Duplicate data set name: "tile_list"`
2. a56939a5aa11f7cd6940d52cbbab40df3c7e330d Allow manually overriding the width and height, which are used to compute the transform_filter that filters out tiles that are off screen. This is needed to fix a weird bug where `width` or `height` are set to 0 in vconcat and hconcat.

I also played around with a hacky fix just detecting if width or height were zero and defaulting to a big number (e.g. `windowSize()`), but I figured just allowing the width and height to be set to be much cleaner.

Thanks,
M